### PR TITLE
Fix 1.0 branch composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         "dynamic/silverstripe-elemental-baseobject": "^1@dev",
         "silverstripe/vendor-plugin": "^1@dev",
         "sheadawson/silverstripe-linkable": "^2@dev",
-        "silverstripe/recipe-cms": ",^1@dev || ^4@dev",
+        "silverstripe/recipe-cms": "^1@dev || ^4@dev",
         "symbiote/silverstripe-gridfieldextensions": "^3.1@dev"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "^5.7",
+        "phpunit/phpunit": "^5.7",
         "squizlabs/php_codesniffer": "*"
     },
     "config": {


### PR DESCRIPTION
Hey,

Due to some strictness fixes in composer and packagist, we are going to have to delete a few of your old versions which contain the typo I fixed here. The versions are 1.0.1, 1.0.2 and 1.0.x-dev (the branch I'm patching).

If you could merge this PR and release a new 1.0.3 with the fix that would be the best way forward IMO, so users still relying on 1.x will get a new version they can actually install.

Thanks and sorry for the trouble, but this is one of the very few packages affected so IMO it's worth cleaning things up.